### PR TITLE
Fix waiting for results and support web sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Environments
+__pycache__
 .env
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All below commands are run from within the root of this folder.
 
 ### Install dependencies
 
-`pip install requests && pip install dotenv && pip install arcgis`
+`pip install requests && pip install polling && pip install dotenv && pip install arcgis`
 
 ### Run The Script
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All below commands are run from within the root of this repository.
 
 ### Install dependencies
 
-`pip install requests && pip install polling && pip install dotenv && pip install arcgis`
+`(venv) $ pip install requests && pip install polling && pip install dotenv && pip install arcgis && pip install websockets`
 
 ### Run The Script
 
@@ -50,7 +50,7 @@ Once you have:
 1) Created your `.env` file 
 2) Created and activated the virtual directory
 
-Run the script with `python3 run_vertigis_workflow.py`
+Run the script with `(venv) $ python3 run_vertigis_workflow.py`
 
 ### Deactive the virtual environment
 
@@ -61,4 +61,6 @@ Run the script with `python3 run_vertigis_workflow.py`
 
 - The server from the `WORKFLOW_SERVER_URL` in the .env file must expose an `/auth/token/run` endpoint, and this must be the same server hosting the `WORKFLOW_ID` in the .env file. If it is not, authentication will fail.
 
-- The script prints the result of a `Set Workflow Output` Activity, where the `Name` field is `output`.
+- The script prints the result of the `Set Workflow Output` Activity from the workflow being run.
+
+- Websockets are used by default to connect with the `/job/artifacts` endpoints as an optimization. If websockets are not permitted on your server, you can set `use_websockets = False` and the script will use requests with polling.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ It is particularly valuable for automating business logic on a recurring schedul
 
 ## Requirements
 
-- Python 3.12.3 or later
+- Python `3.12`\
+    (The `arcgis` package will not work with Python `3.13`.)
 
 ## Storing Credentials
 
@@ -13,16 +14,15 @@ This script reads sensitive ArcGIS Credentials from an `.env` file located at th
 
 ```
 ARCGIS_USERNAME=<your_arcgis_username>
-ARCGIS_PORTAL_URL=https://<server>/portal
 ARCGIS_PASSWORD=<your_arcgis_password>
-
-WORKFLOW_URL=https://<server>/vertigisstudio/workflow/service
-WORKFLOW_ID=<your_workflow_id_to_run>
+ARCGIS_PORTAL_URL=https://<server>/portal
+WORKFLOW_SERVER_URL=https://<server>/vertigisstudio/workflow/service
+WORKFLOW_ID=<item_id_of_workflow_to_run>
 ```
 
 ## Setting Up Your Environment
 
-All below commands are run from within the root of this folder.
+All below commands are run from within the root of this repository.
 
 ### Create a virtual environment
 
@@ -59,6 +59,6 @@ Run the script with `python3 run_vertigis_workflow.py`
 ## Considerations
 - This script makes use of VertiGIS RESTful API endpoints. You can view the endpoints and send sample requests at `https://<server>/vertigisstudio/workflow/service/specification`. 
 
-- The server from the `WORKFLOW_URL` in the .env file must expose an `/auth/token/run` endpoint, and this must be the same server hosting the `WORKFLOW_ID` in the .env file. If it is not, authentication will fail.
+- The server from the `WORKFLOW_SERVER_URL` in the .env file must expose an `/auth/token/run` endpoint, and this must be the same server hosting the `WORKFLOW_ID` in the .env file. If it is not, authentication will fail.
 
 - The script prints the result of a `Set Workflow Output` Activity, where the `Name` field is `output`.

--- a/run_vertigis_workflow.py
+++ b/run_vertigis_workflow.py
@@ -1,19 +1,16 @@
 import os
-import sys
-import time
 import logging
 import requests
 import polling
 from dotenv import load_dotenv
 from arcgis.gis import GIS
-from datetime import datetime
 
 # Configuration
 load_dotenv()
 username = os.getenv("ARCGIS_USERNAME")
 password = os.getenv("ARCGIS_PASSWORD")
 portal_url = os.getenv("ARCGIS_PORTAL_URL")
-workflow_url = os.getenv("WORKFLOW_URL")
+workflow_server_url = os.getenv("WORKFLOW_SERVER_URL")
 workflow_id = os.getenv("WORKFLOW_ID")
 
 polling_timeout = 300  # 5 minutes
@@ -31,8 +28,8 @@ logging.basicConfig(
 )
 
 def run_vertigis_workflow(esri_token):
-    # Generate vertigis token
-    auth_token_run_url = workflow_url + "/auth/token/run"
+    # Generate Access Token
+    auth_token_run_url = workflow_server_url + "/auth/token/run"
     headers = {
         "Content-Type": "application/json"
     }
@@ -40,68 +37,50 @@ def run_vertigis_workflow(esri_token):
         "accessToken": esri_token,
         "portalUrl": portal_url,
     }
-    vertigis_token = polling.poll(
-        lambda: requests.post(auth_token_run_url, headers=headers, json=payload, verify=verify_cert).json().get("token"),
-        check_success=lambda token: token is not None,
-        step = polling_step,
-        timeout = polling_timeout
-    )
-    logging.info("VertiGIS Token: " + vertigis_token)
+    response = requests.post(auth_token_run_url, headers=headers, json=payload, verify=False)
+    vertigis_token = response.json().get("token")
+    logging.info("VertiGIS Workflow Access Token: " + vertigis_token)
     headers["Authorization"] = f"Bearer {vertigis_token}"
    
-    # Submit job
-    job_run_url = workflow_url + "/job/run"
+    # Submit Job
+    job_run_url = workflow_server_url + "/job/run"
     payload = {
         "workflow": {
             "id": workflow_id
         },
         "inputs": {}
     }
-    ticket = polling.poll(
-        lambda: requests.post(job_run_url, headers=headers, json=payload, verify=verify_cert).json().get("ticket"),
-        check_success = lambda ticket: ticket is not None,
-        step = polling_step,
-        timeout = polling_timeout
-    )
-    logging.info("VertiGIS Ticket: " + ticket)
+    response = requests.post(job_run_url, headers=headers, json=payload, verify=False)
+    ticket = response.json().get("ticket")
+    logging.info("VertiGIS Workflow Job Ticket: " + ticket)
 
-    # Get job artifacts
-    artifacts_url = workflow_url + "/job/artifacts"
+    # Get Job Artifacts
+    artifacts_url = workflow_server_url + "/job/artifacts"
     params = {
         "ticket": ticket
     }
-    def get_tag():
+    def get_outputs():
         data = requests.get(artifacts_url, params=params, headers=headers, verify=verify_cert).json()
         results = data.get("results", [])
         if results:
-            return results[0].get("tag")
+            job_quit_artifact = next((artifact for artifact in results if artifact.get("$type") == "JobQuit"), None)
+            if job_quit_artifact:
+                job_result_artifact = next((artifact for artifact in results if artifact.get("$type") == "JobResult"), None)
+                if job_result_artifact:
+                    return job_result_artifact.get("outputs")
         return None
-    tag = polling.poll(
-        get_tag,
+    outputs = polling.poll(
+        get_outputs,
         check_success=lambda v: v is not None,
         step=polling_step,
         timeout=polling_timeout
     )
-    logging.info("VertiGIS Job Artifacts Tag: " + tag)
-
-    # Get job result
-    result_url = workflow_url + "/job/result"
-    params = {
-        "ticket": ticket,
-        "tag": tag
-    }
-    output = polling.poll(
-        lambda: requests.get(result_url, params=params, headers=headers, verify=verify_cert).json().get("output"),
-        check_success=lambda output: output is not None,
-        step = polling_step,
-        timeout = polling_timeout
-    )
-    logging.info("VertiGIS Output: " + output)
-    print(output)
+    logging.info("VertiGIS Workflow Outputs: " + outputs)
+    print(outputs)
 
 
 def main():
-    esri_token: None
+    esri_token = None
     try:
         gis = GIS(portal_url, username, password, verify_cert=verify_cert)
         logging.info(f"Successfully logged in to GIS Portal as: {gis.users.me.username}")
@@ -111,11 +90,12 @@ def main():
         logging.error(f"Error logging into GIS Portal: {e}")
         print(f"Error logging into GIS Portal: {e}")
 
-    try:
-        run_vertigis_workflow(esri_token)
-    except Exception as e:
-        logging.error(f"Error running VertiGIS Workflow: {e}")
-        print(f"Error running VertiGIS Workflow: {e}")
+    if esri_token is not None:
+        try:
+            run_vertigis_workflow(esri_token)
+        except Exception as e:
+            logging.error(f"Error running VertiGIS Workflow: {e}")
+            print(f"Error running VertiGIS Workflow: {e}")
 
     print(f"\nLogs are available at: {log_filename}")
     logging.info("\n\n\n=========================================================================================\n\n")

--- a/run_vertigis_workflow.py
+++ b/run_vertigis_workflow.py
@@ -20,7 +20,7 @@ workflow_id = os.getenv("WORKFLOW_ID")
 use_websockets = True          # Uses Polling when set to False.
 polling_timeout = 300          # 5 minutes
 polling_step = 1
-verify_cert = False            # Warning: It is a securtity risk to set this to False.
+verify_cert = True             # Warning: It is a securtity risk to set this to False.
 log_filename = "Log_File.log"
 
 logging.basicConfig(

--- a/run_vertigis_workflow.py
+++ b/run_vertigis_workflow.py
@@ -2,7 +2,8 @@ import os
 import sys
 import time
 import logging
-import requests 
+import requests
+import polling
 from dotenv import load_dotenv
 from arcgis.gis import GIS
 from datetime import datetime
@@ -15,8 +16,13 @@ portal_url = os.getenv("ARCGIS_PORTAL_URL")
 workflow_url = os.getenv("WORKFLOW_URL")
 workflow_id = os.getenv("WORKFLOW_ID")
 
+polling_timeout = 300  # 5 minutes
+polling_step = 1
+
+verify_cert = True # Warning: It is a securtity risk to set this to False.
 
 log_filename = "Log_File.log"
+
 logging.basicConfig(
     filename=log_filename,
     level=logging.INFO,
@@ -24,20 +30,24 @@ logging.basicConfig(
     filemode='a'  # Append mode to keep existing logs and add new lines
 )
 
-def run_vertigis_workflow(esriToken):
+def run_vertigis_workflow(esri_token):
     # Generate vertigis token
     auth_token_run_url = workflow_url + "/auth/token/run"
     headers = {
         "Content-Type": "application/json"
     }
     payload = {
-        "accessToken": esriToken,
+        "accessToken": esri_token,
         "portalUrl": portal_url,
     }
-    response = requests.post(auth_token_run_url, headers=headers, json=payload, verify=False)
-    logging.info(f"VertiGIS Auth Token Response: {response.status_code} - {response.text}")
-    vertigisToken = response.json().get("token")
-    headers["Authorization"] = f"Bearer {vertigisToken}"
+    vertigis_token = polling.poll(
+        lambda: requests.post(auth_token_run_url, headers=headers, json=payload, verify=verify_cert).json().get("token"),
+        check_success=lambda token: token is not None,
+        step = polling_step,
+        timeout = polling_timeout
+    )
+    logging.info("VertiGIS Token: " + vertigis_token)
+    headers["Authorization"] = f"Bearer {vertigis_token}"
    
     # Submit job
     job_run_url = workflow_url + "/job/run"
@@ -47,18 +57,32 @@ def run_vertigis_workflow(esriToken):
         },
         "inputs": {}
     }
-    response = requests.post(job_run_url, headers=headers, json=payload, verify=False)
-    ticket = response.json().get("ticket")
-    logging.info(f"VertiGIS Submit Job Response: {response.status_code} - {response.text}")
+    ticket = polling.poll(
+        lambda: requests.post(job_run_url, headers=headers, json=payload, verify=verify_cert).json().get("ticket"),
+        check_success = lambda ticket: ticket is not None,
+        step = polling_step,
+        timeout = polling_timeout
+    )
+    logging.info("VertiGIS Ticket: " + ticket)
 
     # Get job artifacts
     artifacts_url = workflow_url + "/job/artifacts"
     params = {
         "ticket": ticket
     }
-    response = requests.get(artifacts_url, params=params, headers=headers, verify=False)
-    tag = response.json().get("results")[0].get("tag")
-    logging.info(f"VertiGIS Job Artifacts Response: {response.status_code} - {response.text}")
+    def get_tag():
+        data = requests.get(artifacts_url, params=params, headers=headers, verify=verify_cert).json()
+        results = data.get("results", [])
+        if results:
+            return results[0].get("tag")
+        return None
+    tag = polling.poll(
+        get_tag,
+        check_success=lambda v: v is not None,
+        step=polling_step,
+        timeout=polling_timeout
+    )
+    logging.info("VertiGIS Job Artifacts Tag: " + tag)
 
     # Get job result
     result_url = workflow_url + "/job/result"
@@ -66,27 +90,29 @@ def run_vertigis_workflow(esriToken):
         "ticket": ticket,
         "tag": tag
     }
-    response = requests.get(result_url, params=params, headers=headers, verify=False)
-    output = response.json().get("output")
-    logging.info(f"VertiGIS Job Results Response: {response.status_code} - {response.text}")
-    
-    # Workflow has finished executing, print workflow output.
+    output = polling.poll(
+        lambda: requests.get(result_url, params=params, headers=headers, verify=verify_cert).json().get("output"),
+        check_success=lambda output: output is not None,
+        step = polling_step,
+        timeout = polling_timeout
+    )
+    logging.info("VertiGIS Output: " + output)
     print(output)
 
 
 def main():
-    esriToken: None
+    esri_token: None
     try:
-        gis = GIS(portal_url, username, password, verify_cert=False)
+        gis = GIS(portal_url, username, password, verify_cert=verify_cert)
         logging.info(f"Successfully logged in to GIS Portal as: {gis.users.me.username}")
-        esriToken = gis._con.token
-        logging.info(f"ArgGIS Token: {esriToken}")
+        esri_token = gis._con.token
+        logging.info(f"ArgGIS Token: {esri_token}")
     except Exception as e:
         logging.error(f"Error logging into GIS Portal: {e}")
         print(f"Error logging into GIS Portal: {e}")
 
     try:
-        run_vertigis_workflow(esriToken)
+        run_vertigis_workflow(esri_token)
     except Exception as e:
         logging.error(f"Error running VertiGIS Workflow: {e}")
         print(f"Error running VertiGIS Workflow: {e}")

--- a/run_vertigis_workflow.py
+++ b/run_vertigis_workflow.py
@@ -1,9 +1,13 @@
-import os
+import asyncio
+import json
 import logging
-import requests
+import os
 import polling
-from dotenv import load_dotenv
+import requests
+import ssl
 from arcgis.gis import GIS
+from dotenv import load_dotenv
+from websockets.asyncio.client import connect
 
 # Configuration
 load_dotenv()
@@ -13,21 +17,20 @@ portal_url = os.getenv("ARCGIS_PORTAL_URL")
 workflow_server_url = os.getenv("WORKFLOW_SERVER_URL")
 workflow_id = os.getenv("WORKFLOW_ID")
 
-polling_timeout = 300  # 5 minutes
+use_websockets = True          # Uses Polling when set to False.
+polling_timeout = 300          # 5 minutes
 polling_step = 1
-
-verify_cert = True # Warning: It is a securtity risk to set this to False.
-
+verify_cert = False            # Warning: It is a securtity risk to set this to False.
 log_filename = "Log_File.log"
 
 logging.basicConfig(
     filename=log_filename,
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",
-    filemode='a'  # Append mode to keep existing logs and add new lines
+    filemode='a'                # Append mode to keep existing logs and add new lines
 )
 
-def run_vertigis_workflow(esri_token):
+async def run_vertigis_workflow(esri_token):
     # Generate Access Token
     auth_token_run_url = workflow_server_url + "/auth/token/run"
     headers = {
@@ -39,9 +42,12 @@ def run_vertigis_workflow(esri_token):
     }
     response = requests.post(auth_token_run_url, headers=headers, json=payload, verify=False)
     vertigis_token = response.json().get("token")
-    logging.info("VertiGIS Workflow Access Token: " + vertigis_token)
+    if (vertigis_token is None):
+        logging.info("Failed to retrieve VertiGIS Workflow Access Token from " + auth_token_run_url)
+    else:
+        logging.info("VertiGIS Workflow Access Token: " + vertigis_token)
     headers["Authorization"] = f"Bearer {vertigis_token}"
-   
+
     # Submit Job
     job_run_url = workflow_server_url + "/job/run"
     payload = {
@@ -59,9 +65,7 @@ def run_vertigis_workflow(esri_token):
     params = {
         "ticket": ticket
     }
-    def get_outputs():
-        data = requests.get(artifacts_url, params=params, headers=headers, verify=verify_cert).json()
-        results = data.get("results", [])
+    def get_outputs(results):
         if results:
             job_quit_artifact = next((artifact for artifact in results if artifact.get("$type") == "JobQuit"), None)
             if job_quit_artifact:
@@ -69,17 +73,50 @@ def run_vertigis_workflow(esri_token):
                 if job_result_artifact:
                     return job_result_artifact.get("outputs")
         return None
-    outputs = polling.poll(
-        get_outputs,
-        check_success=lambda v: v is not None,
-        step=polling_step,
-        timeout=polling_timeout
-    )
-    logging.info("VertiGIS Workflow Outputs: " + outputs)
+    def wait_for_job_result_polling():
+        def get_polling_outputs():
+            data = requests.get(artifacts_url, params=params, headers=headers, verify=verify_cert).json()
+            results = data.get("results", [])
+            return get_outputs(results)
+        outputs = polling.poll(
+            get_polling_outputs,
+            check_success=lambda v: v is not None,
+            step=polling_step,
+            timeout=polling_timeout
+        )
+        return outputs
+    async def wait_for_job_result_websocket():
+        # If 'https', this will intentionally result is 'wss' 
+        websocket_artifacts_url = artifacts_url.replace("http",  "ws")
+        artifacts_service_url = f"{websocket_artifacts_url}?ticket={ticket}"
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+        async with connect(artifacts_service_url, ssl=True if verify_cert == True else ssl_context) as websocket:
+            message = await websocket.recv()
+            data = json.loads(message)
+            results = data.get("results", [])
+            return get_outputs(results)
+    outputs = None
+    if (use_websockets):
+        outputs = await wait_for_job_result_websocket()
+    else:
+        outputs = wait_for_job_result_polling()
+    logging.info(f"VertiGIS Workflow Outputs: {outputs}")
     print(outputs)
 
 
-def main():
+async def main():
+    global username
+    global password
+    global portal_url
+
+    if (password == ""):
+        password = None
+
+    if (portal_url == ""):
+        portal_url = None
+
     esri_token = None
     try:
         gis = GIS(portal_url, username, password, verify_cert=verify_cert)
@@ -92,7 +129,7 @@ def main():
 
     if esri_token is not None:
         try:
-            run_vertigis_workflow(esri_token)
+            await run_vertigis_workflow(esri_token)
         except Exception as e:
             logging.error(f"Error running VertiGIS Workflow: {e}")
             print(f"Error running VertiGIS Workflow: {e}")
@@ -100,6 +137,5 @@ def main():
     print(f"\nLogs are available at: {log_filename}")
     logging.info("\n\n\n=========================================================================================\n\n")
 
-
 if __name__ == "__main__":
-    main()
+    asyncio.run(main()) 


### PR DESCRIPTION
The initial implementation wasn't inspecting the artifacts correctly to determine if the job was finished.

Also, we now use web sockets by default to connect to Workflow server. If for any reason web sockets are disabled on the server, you can set `use_websockets` to `False` and polling will be used instead.

If the `ARCGIS_PASSWORD` environment variable is an empty string, it's now changed to `None` to cause the user to be prompted for a password.

If the `ARCGIS_PORTAL_URL` environment variable is an empty string, it's now changed to `None` to connect to ArcGIS Online by default.
